### PR TITLE
jsObj(undefined) could return undefined

### DIFF
--- a/lib/secure-filters.js
+++ b/lib/secure-filters.js
@@ -212,6 +212,8 @@ secureFilters.uri = function(val) {
  * @return {string} the JSON- and backslash-encoded string
  */
 secureFilters.jsObj = function(val) {
+  if(val === undefined) return val;
+
   return JSON.stringify(val)
     .replace(JSON_NOT_WHITELISTED, jsSlashEncoder)
     // prevent breaking out of CDATA context.  Escaping < below is sufficient


### PR DESCRIPTION
Crashes with `TypeError`, could simply allow `undefined` to pass through.